### PR TITLE
fix(IIFE): replace 'Intermediate'

### DIFF
--- a/code/6-why-you-can-chain-filters/higherorder-functions.js
+++ b/code/6-why-you-can-chain-filters/higherorder-functions.js
@@ -1,4 +1,4 @@
-// IIFE Intermediate invoked function expression
+// IIFE immediately-invoked function expression
 (function() {
   'use strict';
 


### PR DESCRIPTION
Hi,
wir sind gestern über das Video von deinem AngularJS Workshop gestolpert (sehr gut aufgebaut!). Kleine Korrektur: IIFE ist die Abkürzung für `Immediately-invoked function expression`.
